### PR TITLE
soong: Add support for vendor_overlay

### DIFF
--- a/android/androidmk.go
+++ b/android/androidmk.go
@@ -193,6 +193,7 @@ func (a *AndroidMkEntries) fillInEntries(config Config, bpPath string, mod bluep
 		if Bool(amod.commonProperties.Vendor) || Bool(amod.commonProperties.Soc_specific) {
 			a.SetString("LOCAL_VENDOR_MODULE", "true")
 		}
+		a.SetBoolIfTrue("LOCAL_VENDOR_OVERLAY_MODULE", Bool(amod.commonProperties.Vendor_overlay))
 		a.SetBoolIfTrue("LOCAL_ODM_MODULE", Bool(amod.commonProperties.Device_specific))
 		a.SetBoolIfTrue("LOCAL_PRODUCT_MODULE", Bool(amod.commonProperties.Product_specific))
 		a.SetBoolIfTrue("LOCAL_PRODUCT_SERVICES_MODULE", Bool(amod.commonProperties.Product_services_specific))

--- a/android/config.go
+++ b/android/config.go
@@ -829,6 +829,13 @@ func (c *deviceConfig) VendorPath() string {
 	return "vendor"
 }
 
+func (c *deviceConfig) VendorOverlayPath() string {
+        if c.config.productVariables.VendorOverlayPath != nil {
+                return *c.config.productVariables.VendorOverlayPath
+        }
+        return "vendor_overlay"
+}
+
 func (c *deviceConfig) VndkVersion() string {
 	return String(c.config.productVariables.DeviceVndkVersion)
 }

--- a/android/module.go
+++ b/android/module.go
@@ -72,6 +72,7 @@ type androidBaseContext interface {
 	Platform() bool
 	DeviceSpecific() bool
 	SocSpecific() bool
+	VendorOverlay() bool
 	ProductSpecific() bool
 	ProductServicesSpecific() bool
 	AConfig() Config
@@ -239,6 +240,10 @@ type commonProperties struct {
 	// Use `soc_specific` instead for better meaning.
 	Vendor *bool
 
+	// whether this module is specific to an SoC (System-On-a-Chip) and the build is system-only.
+	// When set to true, it is installed into $(TARGET_COPY_OUT_PRODUCT)/vendor_overlay/$(PRODUCT_TARGET_VNDK_VERSION)
+        Vendor_overlay *bool
+
 	// whether this module is specific to an SoC (System-On-a-Chip). When set to true,
 	// it is installed into /vendor (or /system/vendor if vendor partition does not exist).
 	Soc_specific *bool
@@ -359,6 +364,7 @@ const (
 	platformModule moduleKind = iota
 	deviceSpecificModule
 	socSpecificModule
+	vendorOverlayModule
 	productSpecificModule
 	productServicesSpecificModule
 )
@@ -371,6 +377,8 @@ func (k moduleKind) String() string {
 		return "device-specific"
 	case socSpecificModule:
 		return "soc-specific"
+	case vendorOverlayModule:
+		return "vendor-overlay"
 	case productSpecificModule:
 		return "product-specific"
 	case productServicesSpecificModule:
@@ -604,7 +612,7 @@ func (a *ModuleBase) DeviceSupported() bool {
 }
 
 func (a *ModuleBase) Platform() bool {
-	return !a.DeviceSpecific() && !a.SocSpecific() && !a.ProductSpecific() && !a.ProductServicesSpecific()
+	return !a.DeviceSpecific() && !a.SocSpecific() && !a.ProductSpecific() && !a.ProductServicesSpecific() && !a.VendorOverlay()
 }
 
 func (a *ModuleBase) DeviceSpecific() bool {
@@ -613,6 +621,10 @@ func (a *ModuleBase) DeviceSpecific() bool {
 
 func (a *ModuleBase) SocSpecific() bool {
 	return Bool(a.commonProperties.Vendor) || Bool(a.commonProperties.Proprietary) || Bool(a.commonProperties.Soc_specific)
+}
+
+func (a *ModuleBase) VendorOverlay() bool {
+	return Bool(a.commonProperties.Vendor_overlay)
 }
 
 func (a *ModuleBase) ProductSpecific() bool {
@@ -743,6 +755,7 @@ func (a *ModuleBase) generateModuleTarget(ctx ModuleContext) {
 
 func determineModuleKind(a *ModuleBase, ctx blueprint.BaseModuleContext) moduleKind {
 	var socSpecific = Bool(a.commonProperties.Vendor) || Bool(a.commonProperties.Proprietary) || Bool(a.commonProperties.Soc_specific)
+	var vendorOverlay = Bool(a.commonProperties.Vendor_overlay)
 	var deviceSpecific = Bool(a.commonProperties.Device_specific)
 	var productSpecific = Bool(a.commonProperties.Product_specific)
 	var productServicesSpecific = Bool(a.commonProperties.Product_services_specific)
@@ -755,6 +768,9 @@ func determineModuleKind(a *ModuleBase, ctx blueprint.BaseModuleContext) moduleK
 		}
 		if Bool(a.commonProperties.Proprietary) {
 			ctx.PropertyErrorf("proprietary", msg)
+		}
+		if Bool(a.commonProperties.Vendor_overlay) {
+			ctx.PropertyErrorf("vendor_overlay", msg)
 		}
 		if Bool(a.commonProperties.Soc_specific) {
 			ctx.PropertyErrorf("soc_specific", msg)
@@ -781,6 +797,9 @@ func determineModuleKind(a *ModuleBase, ctx blueprint.BaseModuleContext) moduleK
 			if Bool(a.commonProperties.Proprietary) {
 				ctx.PropertyErrorf("proprietary", msg)
 			}
+			if Bool(a.commonProperties.Vendor_overlay) {
+				ctx.PropertyErrorf("vendor_overlay", msg)
+			}
 			if Bool(a.commonProperties.Soc_specific) {
 				ctx.PropertyErrorf("soc_specific", msg)
 			}
@@ -793,6 +812,8 @@ func determineModuleKind(a *ModuleBase, ctx blueprint.BaseModuleContext) moduleK
 		return productServicesSpecificModule
 	} else if deviceSpecific {
 		return deviceSpecificModule
+	} else if vendorOverlay {
+		return vendorOverlayModule
 	} else if socSpecific {
 		return socSpecificModule
 	} else {
@@ -1251,6 +1272,10 @@ func (a *androidBaseContextImpl) ProductServicesSpecific() bool {
 	return a.kind == productServicesSpecificModule
 }
 
+func (a *androidBaseContextImpl) VendorOverlay() bool {
+	return a.kind == vendorOverlayModule
+}
+
 // Makes this module a platform module, i.e. not specific to soc, device,
 // product, or product_services.
 func (a *ModuleBase) MakeAsPlatform() {
@@ -1259,6 +1284,7 @@ func (a *ModuleBase) MakeAsPlatform() {
 	a.commonProperties.Soc_specific = boolPtr(false)
 	a.commonProperties.Product_specific = boolPtr(false)
 	a.commonProperties.Product_services_specific = boolPtr(false)
+	a.commonProperties.Vendor_overlay = boolPtr(false)
 }
 
 func (a *androidModuleContext) InstallInData() bool {

--- a/android/paths.go
+++ b/android/paths.go
@@ -1175,6 +1175,8 @@ func modulePartition(ctx ModuleInstallPathContext) string {
 		partition = "recovery/root/system"
 	} else if ctx.SocSpecific() {
 		partition = ctx.DeviceConfig().VendorPath()
+	} else if ctx.VendorOverlay() {
+		partition = ctx.DeviceConfig().VendorOverlayPath()
 	} else if ctx.DeviceSpecific() {
 		partition = ctx.DeviceConfig().OdmPath()
 	} else if ctx.ProductSpecific() {

--- a/android/variable.go
+++ b/android/variable.go
@@ -226,6 +226,7 @@ type productVariables struct {
 	XOMExcludePaths []string `json:",omitempty"`
 
 	VendorPath          *string `json:",omitempty"`
+	VendorOverlayPath   *string `json:",omitempty"`
 	OdmPath             *string `json:",omitempty"`
 	ProductPath         *string `json:",omitempty"`
 	ProductServicesPath *string `json:",omitempty"`

--- a/androidmk/cmd/androidmk/android.go
+++ b/androidmk/cmd/androidmk/android.go
@@ -189,6 +189,7 @@ func init() {
 			"LOCAL_USE_CLANG_LLD":              "use_clang_lld",
 			"LOCAL_PROPRIETARY_MODULE":         "proprietary",
 			"LOCAL_VENDOR_MODULE":              "vendor",
+			"LOCAL_VENDOR_OVERLAY_MODULE":      "vendor_overlay",
 			"LOCAL_ODM_MODULE":                 "device_specific",
 			"LOCAL_PRODUCT_MODULE":             "product_specific",
 			"LOCAL_PRODUCT_SERVICES_MODULE":    "product_services_specific",

--- a/cc/cc.go
+++ b/cc/cc.go
@@ -2145,7 +2145,7 @@ func ImageMutator(mctx android.BottomUpMutatorContext) {
 	}
 
 	// Sanity check
-	vendorSpecific := mctx.SocSpecific() || mctx.DeviceSpecific()
+	vendorSpecific := mctx.SocSpecific() || mctx.DeviceSpecific() || mctx.VendorOverlay()
 	productSpecific := mctx.ProductSpecific()
 
 	if m.VendorProperties.Vendor_available != nil && vendorSpecific {


### PR DESCRIPTION
Known Issue:
etc modules go to product/etc instead of product/vendor_overlay/29/etc

Change-Id: I726af4999cf44c854cdde7e21a8f396ee4063f4d
Signed-off-by: Ahmad Thoriq Najahi <najahi@chips-projects.xyz>